### PR TITLE
feat: change `gitmeta image tag` to be based on `git describe`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REPO ?= docker.io/autonomy
-GOLANG_IMAGE ?= golang:1.12.6
+GOLANG_IMAGE ?= golang:1.13.1
 
 TAG := $(shell gitmeta image tag)
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/talos-systems/gitmeta
 
+go 1.13
+
 require (
 	github.com/Masterminds/semver v1.4.2
 	github.com/gliderlabs/ssh v0.2.2 // indirect

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strings"
 
 	billy "gopkg.in/src-d/go-billy.v4"
 	"gopkg.in/src-d/go-billy.v4/memfs"
@@ -123,6 +124,26 @@ func (g *Git) Tag() (tag string, isTag bool, err error) {
 	}
 
 	return tag, isTag, err
+}
+
+// Describe returns git describe-based version.
+//
+//If no tags are present: `8513435-dirty` or `8513435`
+//
+// Exactly on the tag `v0.1`: `v0.1-dirty` or `v0.1`
+//
+// Some commits ahead of tag `v0.1`: `v0.1-1-g23cbce5` (1 commit ahead, `g`
+// followed by abbreviated git SHA).
+func (g *Git) Describe() (result string, err error) {
+	var describeResult []byte
+	describeResult, err = exec.Command("git", "describe", "--tags", "--always", "--dirty").Output()
+	if err != nil {
+		return
+	}
+
+	result = strings.TrimSpace(string(describeResult))
+
+	return
 }
 
 // Status returns the status of the working tree.

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -36,6 +36,7 @@ type Git struct {
 	SHA      string
 	Tag      string
 	Status   string
+	Describe string
 	IsBranch bool
 	IsClean  bool
 	IsTag    bool
@@ -66,12 +67,6 @@ func NewMetadata(git *git.Git) (m *Metadata, err error) {
 		return nil, err
 	}
 
-	// Override the container image if the working tree is not dirty and the
-	// current commit is a tag.
-	if m.Git.IsClean && m.Git.IsTag {
-		m.Container.Image.Tag = m.Git.Tag
-	}
-
 	return m, nil
 }
 
@@ -98,7 +93,7 @@ func addMetadataForVersion(m *Metadata) error {
 
 //nolint: unparam
 func addMetadataForContainer(m *Metadata) error {
-	tag := m.Git.SHA
+	tag := m.Git.Describe
 
 	containerMetadata := &Container{
 		Image: &Image{
@@ -130,6 +125,9 @@ func addMetadataForGit(m *Metadata) (err error) {
 		return err
 	}
 	if err = addTagMetadataForGit(m.git, m); err != nil {
+		return err
+	}
+	if err = addDescribeMetadataForGit(m.git, m); err != nil {
 		return err
 	}
 
@@ -205,6 +203,16 @@ func addTagMetadataForGit(g *git.Git, m *Metadata) error {
 	} else {
 		m.Git.Tag = "none"
 	}
+
+	return nil
+}
+
+func addDescribeMetadataForGit(g *git.Git, m *Metadata) error {
+	describe, err := g.Describe()
+	if err != nil {
+		return err
+	}
+	m.Git.Describe = describe
 
 	return nil
 }


### PR DESCRIPTION
This runs `git describe --tags --always --dirty`, behavior is described
in comments.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>